### PR TITLE
Create Crossentropy-Bart-Fixed.py

### DIFF
--- a/Cross entropy - Bart -Fixed.py
+++ b/Cross entropy - Bart -Fixed.py
@@ -1,0 +1,29 @@
+ import torch
+from transformers import BartForConditionalGeneration, BartTokenizer
+
+model_name = "facebook/bart-base"
+model = BartForConditionalGeneration.from_pretrained(model_name)
+tokenizer = BartTokenizer.from_pretrained(model_name)
+
+input = [
+    "Long live America.",
+    "I love Huggingface as it has made the ML development so easy."
+]
+
+input_tok = tokenizer(input, return_tensors='pt', padding=True)
+
+with torch.no_grad():
+    out = model(input_tok['input_ids'], labels=input_tok['input_ids'])
+
+default_loss = out.loss
+
+# Ensure that the ignore_index matches the pad token ID in the model's configuration
+criterion = torch.nn.CrossEntropyLoss(ignore_index=model.config.pad_token_id)
+
+# Reshape logits and input_ids before calculating the loss
+logits = out.logits.view(-1, out.logits.size(-1))
+input_ids = input_tok['input_ids'].view(-1)
+should_be_loss = criterion(logits, input_ids)
+
+print("Default Loss:", default_loss.item())
+print("Should Be Loss:", should_be_loss.item())


### PR DESCRIPTION
The code snippet demonstrates the process of fine-tuning a pre-trained BART (Bidirectional and AutoRegressive Transformers) model using the Hugging Face Transformers library and calculates the loss using a custom criterion. The goal is to compare this custom loss with the default loss provided by the model.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (27057)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker and @younesbelkada
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @gante
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @pacman100

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc and @younesbelkada

Documentation: @stevhliu and @MKhalusova

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
